### PR TITLE
predict.prototxt fix

### DIFF
--- a/scripts/create_models.py
+++ b/scripts/create_models.py
@@ -607,7 +607,6 @@ if __name__ == '__main__':
         fp.close()
 
         subprocess.check_output(
-            #['python', '%s/Libraries/caffe/python/draw_net.py' % home_dir,
-            ['python', '%s/Downloads/caffe_dev_mitmul/caffe_ssai/python/draw_net.py' % home_dir,
+            ['python', '%s/Libraries/caffe/python/draw_net.py' % home_dir,
              'models/%s/train_test.prototxt' % model_name,
              'models/%s/net.png' % model_name])


### PR DESCRIPTION
The patch_transformer layer from the generated predict.prototxt required image_label for the bottom blob. I believe this shoudn't happen, since no labels are supposed to be required for prediction. The changes below make prediction possible. Am I wrong?

Totally unrelated, could you please add a seed for the Plain-Mnih-NN-Multi-S-Maxout with Dropout model used in your article "Building and road detection from large aerial imagery"? My group is working on the same topic and we would love to compare our results [pixel by pixel, if possible] with your predictions.

Cheers.
